### PR TITLE
fix: language selector default color

### DIFF
--- a/src/components/blocks/LocaleSwitcher.js
+++ b/src/components/blocks/LocaleSwitcher.js
@@ -17,6 +17,10 @@ const Container = styled('div')`
     font-family: ${props => props.theme.typography.primary.semiBold};
   }
 
+  .MuiSelect-select {
+    color: ${props => props.theme.colors.default.primary}};
+  }
+
   .MuiSelect-root:hover,
   .MuiSvgIcon-root:hover,
   .MuiSelect-select:hover {
@@ -24,7 +28,8 @@ const Container = styled('div')`
   }
 
   .MuiOutlinedInput-notchedOutline {
-    border: 0;
+    border: 0 !important;
+    outline: 0;
   }
 `;
 


### PR DESCRIPTION
This PR addresses an issue with the language selector in the Climate-Tokenization-Engine-UI where the text color was not visible until hovered over. The default text color has been fixed to ensure visibility at all times.

- Fixed the default text color for the language selector to ensure it is visible without needing to hover.

